### PR TITLE
feat #24: 사용자 상세 정보 조회 기능 구현

### DIFF
--- a/src/main/java/com/codesquad/secondhand/Image/domain/ImageFileDetail.java
+++ b/src/main/java/com/codesquad/secondhand/Image/domain/ImageFileDetail.java
@@ -52,4 +52,8 @@ public class ImageFileDetail {
 	public String getUploadFileName(String prefix) {
 		return String.format("%s/%s", prefix, UUID.randomUUID());
 	}
+
+	public String getOriginalFileName() {
+		return multipartFile.getOriginalFilename();
+	}
 }

--- a/src/main/java/com/codesquad/secondhand/common/response/ResponseMessage.java
+++ b/src/main/java/com/codesquad/secondhand/common/response/ResponseMessage.java
@@ -11,7 +11,8 @@ public enum ResponseMessage {
 	ITEM_FIND_BY_REGION_AND_CATEGORY("상품 목록 조회를 성공하였습니다."),
 	SIGN_UP("회원가입을 성공하였습니다."),
 	SIGN_IN("로그인을 성공하였습니다."),
-	SIGN_OUT("로그아웃을 성공하였습니다.");
+	SIGN_OUT("로그아웃을 성공하였습니다."),
+	USER_INFO("사용자 정보 조회를 성공하였습니다.");
 
 	private final String message;
 

--- a/src/main/java/com/codesquad/secondhand/user/application/dto/UserInfoResponse.java
+++ b/src/main/java/com/codesquad/secondhand/user/application/dto/UserInfoResponse.java
@@ -1,0 +1,25 @@
+package com.codesquad.secondhand.user.application.dto;
+
+import com.codesquad.secondhand.user.domain.User;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+public class UserInfoResponse {
+
+	private Long userId;
+
+	private String nickname;
+
+	private String imageUrl;
+
+	public static UserInfoResponse from(User user) {
+		return new UserInfoResponse(
+			user.getId(),
+			user.getNickname(),
+			user.getImageUrl());
+	}
+}

--- a/src/main/java/com/codesquad/secondhand/user/domain/User.java
+++ b/src/main/java/com/codesquad/secondhand/user/domain/User.java
@@ -2,6 +2,7 @@ package com.codesquad.secondhand.user.domain;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Objects;
 
 import javax.persistence.Embedded;
 import javax.persistence.Entity;
@@ -106,6 +107,14 @@ public class User {
 
 	public Image getImage() {
 		return image;
+	}
+
+	public String getImageUrl() {
+		if(Objects.isNull(this.image)){
+			return null;
+		}
+
+		return image.getImageUrl();
 	}
 
 	public LocalDateTime getCreatedAt() {

--- a/src/main/java/com/codesquad/secondhand/user/ui/UserController.java
+++ b/src/main/java/com/codesquad/secondhand/user/ui/UserController.java
@@ -21,6 +21,7 @@ import com.codesquad.secondhand.common.response.CommonResponse;
 import com.codesquad.secondhand.common.response.ResponseMessage;
 import com.codesquad.secondhand.user.application.UserService;
 import com.codesquad.secondhand.user.application.dto.UserCreateRequest;
+import com.codesquad.secondhand.user.application.dto.UserInfoResponse;
 import com.codesquad.secondhand.user.application.dto.UserRegionAddRequest;
 
 import lombok.RequiredArgsConstructor;
@@ -64,6 +65,15 @@ public class UserController {
 		userService.removeMyRegion(account.getId(), id);
 		return ResponseEntity.status(HttpStatus.NO_CONTENT)
 			.body(CommonResponse.createNoContent(ResponseMessage.MY_REGION_REMOVE));
+	}
+
+	@GetMapping("/info")
+	public ResponseEntity<CommonResponse> showUserInfo(@AccountPrincipal Account account) {
+		return ResponseEntity.ok()
+			.body(CommonResponse.createOK(
+				UserInfoResponse.from(userService.findByIdOrThrow(account.getId())),
+				ResponseMessage.USER_INFO
+			));
 	}
 }
 

--- a/src/test/java/com/codesquad/secondhand/acceptance/AuthAcceptanceTest.java
+++ b/src/test/java/com/codesquad/secondhand/acceptance/AuthAcceptanceTest.java
@@ -65,7 +65,7 @@ public class AuthAcceptanceTest extends AcceptanceTest {
 	@Test
 	void 로그아웃을_한다() {
 		// when
-		var response = 로그아웃_요청(accessToken);
+		var response = 로그아웃_요청(유저_만두_액세스_토큰);
 
 		// then
 		응답_상태코드_검증(response, HttpStatus.NO_CONTENT);

--- a/src/test/java/com/codesquad/secondhand/acceptance/CategoryAcceptanceTest.java
+++ b/src/test/java/com/codesquad/secondhand/acceptance/CategoryAcceptanceTest.java
@@ -25,7 +25,7 @@ public class CategoryAcceptanceTest extends AcceptanceTest {
 	@Test
 	void 카테고리_목록을_조회한다() {
 		// when
-		var response = 카테고리_목록_조회_요청(accessToken);
+		var response = 카테고리_목록_조회_요청(유저_만두_액세스_토큰);
 
 		// then
 		응답_상태코드_검증(response, HttpStatus.OK);

--- a/src/test/java/com/codesquad/secondhand/acceptance/ItemAcceptanceTest.java
+++ b/src/test/java/com/codesquad/secondhand/acceptance/ItemAcceptanceTest.java
@@ -35,7 +35,7 @@ public class ItemAcceptanceTest extends AcceptanceTest {
 	void 전체_상품_목록을_조회한다(int page, int size, boolean expectedHasMore, Long regionId, Long categoryId,
 		List<ItemResponse> expectedItemsResponse) {
 		// when
-		var response = 지역별_카테고리별_상품_목록_조회_요청(accessToken, page, size, regionId, categoryId);
+		var response = 지역별_카테고리별_상품_목록_조회_요청(유저_만두_액세스_토큰, page, size, regionId, categoryId);
 
 		//then
 		응답_상태코드_검증(response, HttpStatus.OK);

--- a/src/test/java/com/codesquad/secondhand/acceptance/RegionAcceptanceTest.java
+++ b/src/test/java/com/codesquad/secondhand/acceptance/RegionAcceptanceTest.java
@@ -29,7 +29,7 @@ public class RegionAcceptanceTest extends AcceptanceTest {
 	@MethodSource("providerPageableAndRegion")
 	void 동네_목록을_조회한다(int page, int size, boolean hasMore, String title, List<String> regionTitles) {
 		// when
-		var response = 동네_목록_조회_요청(accessToken, page, size, title);
+		var response = 동네_목록_조회_요청(유저_만두_액세스_토큰, page, size, title);
 
 		// then
 		응답_상태코드_검증(response, HttpStatus.OK);

--- a/src/test/java/com/codesquad/secondhand/util/AcceptanceTest.java
+++ b/src/test/java/com/codesquad/secondhand/util/AcceptanceTest.java
@@ -30,14 +30,14 @@ public abstract class AcceptanceTest extends MySqlContainer {
 	@Autowired
 	private DatabaseLoader databaseLoader;
 
-	protected String accessToken;
+	protected String 유저_만두_액세스_토큰;
 
 	@BeforeEach
 	void setUp() {
 		RestAssured.port = port;
 		databaseLoader.initData();
 		유저_생성_요청(공급자_내부.getId(), 유저_만두.getEmail(), 유저_만두.getNickname(), 유저_만두.getPassword(), null);
-		accessToken = 로그인_요청(유저_만두.getEmail(), 유저_만두.getPassword()).jsonPath().getString("data.accessToken");
+		유저_만두_액세스_토큰 = 로그인_요청(유저_만두.getEmail(), 유저_만두.getPassword()).jsonPath().getString("data.accessToken");
 		databaseLoader.loadData();
 	}
 

--- a/src/test/java/com/codesquad/secondhand/util/FakeS3Client.java
+++ b/src/test/java/com/codesquad/secondhand/util/FakeS3Client.java
@@ -7,6 +7,6 @@ public class FakeS3Client implements FileClient {
 
 	@Override
 	public String upload(ImageFileDetail imageFileDetail) {
-		return "http://www.image.com/image.jpg";
+		return String.format("http://www.image.com/%s", imageFileDetail.getOriginalFileName());
 	}
 }

--- a/src/test/java/com/codesquad/secondhand/util/steps/UserSteps.java
+++ b/src/test/java/com/codesquad/secondhand/util/steps/UserSteps.java
@@ -66,4 +66,13 @@ public class UserSteps {
 			.when().delete("/api/users/regions/{id}", regionId)
 			.then().log().all().extract();
 	}
+
+	public static ExtractableResponse<Response> 유저_정보_조회_요청(String accessToken) {
+		return RestAssured.given().log().all()
+			.auth().oauth2(accessToken)
+			.accept(MediaType.APPLICATION_JSON_VALUE)
+			.contentType(MediaType.APPLICATION_JSON_VALUE)
+			.when().get("/api/users/info")
+			.then().log().all().extract();
+	}
 }


### PR DESCRIPTION
## 주요 변경 내용
- 사용자 상세 정보 조회 기능 구현
- AcceptanceTest의 accessToken 필드명 변경
accessToken -> 유저_만두_액세스_토큰
- FakeS3Client가 original file name을 반환하도록 변경