### PR TITLE
Fix/#64 관심 내역, 판매 내역, 상품 내역 응답 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,11 @@
 buildscript {
 	ext {
+		awscloudVersion = "2.2.6.RELEASE"
+		parentVersion = "2.7.14"
+		testcontainersVersion = "1.18.3"
+		jjwtVersion = "0.11.5"
 		queryDslVersion = "5.0.0"
+		restassuredVersion = "4.5.1"
 	}
 }
 
@@ -29,27 +34,29 @@ repositories {
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation 'org.testcontainers:mysql:1.18.3'
-	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
-	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
-	implementation 'org.springframework.boot:spring-boot-starter-validation'
-	implementation 'org.springframework.boot:spring-boot-starter-webflux'
-	implementation 'org.springframework.boot:spring-boot-starter-parent:2.7.14'
+	implementation "org.springframework.boot:spring-boot-starter-data-jpa"
+	implementation "org.springframework.boot:spring-boot-starter-web"
+	implementation "org.springframework.boot:spring-boot-starter-validation"
+	implementation "org.springframework.boot:spring-boot-starter-webflux"
+	implementation "org.springframework.boot:spring-boot-starter-data-redis"
+	implementation "org.springframework.boot:spring-boot-starter-cache"
+	implementation "org.springframework.cloud:spring-cloud-starter-aws:${awscloudVersion}"
+	implementation "org.springframework.boot:spring-boot-starter-parent:${parentVersion}"
+	implementation "org.testcontainers:mysql:${testcontainersVersion}"
+	implementation "io.jsonwebtoken:jjwt-api:${jjwtVersion}"
 
 	implementation "com.querydsl:querydsl-jpa:${queryDslVersion}"
 	annotationProcessor "com.querydsl:querydsl-apt:${queryDslVersion}"
 
-	compileOnly 'org.projectlombok:lombok'
-	runtimeOnly 'com.mysql:mysql-connector-j'
-	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
-	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
-	annotationProcessor 'org.projectlombok:lombok'
+	compileOnly "org.projectlombok:lombok"
+	runtimeOnly "com.mysql:mysql-connector-j"
+	runtimeOnly "io.jsonwebtoken:jjwt-impl:${jjwtVersion}"
+	runtimeOnly "io.jsonwebtoken:jjwt-jackson:${jjwtVersion}"
+	annotationProcessor "org.projectlombok:lombok"
 
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testImplementation 'io.rest-assured:rest-assured:4.5.1'
-	testImplementation "org.testcontainers:junit-jupiter:1.18.3"
+	testImplementation "org.springframework.boot:spring-boot-starter-test"
+	testImplementation "io.rest-assured:rest-assured:${restassuredVersion}"
+	testImplementation "org.testcontainers:junit-jupiter:${testcontainersVersion}"
 }
 
 def querydslDir = "$buildDir/generated/querydsl"
@@ -57,12 +64,15 @@ querydsl {
 	jpa = true
 	querydslSourcesDir = querydslDir
 }
+
 sourceSets {
 	main.java.srcDir querydslDir
 }
+
 configurations {
 	querydsl.extendsFrom compileClasspath
 }
+
 compileQuerydsl {
 	options.annotationProcessorPath = configurations.querydsl
 }

--- a/src/main/java/com/codesquad/secondhand/category/application/dto/CategoryInfoResponse.java
+++ b/src/main/java/com/codesquad/secondhand/category/application/dto/CategoryInfoResponse.java
@@ -7,12 +7,12 @@ import lombok.Getter;
 
 @AllArgsConstructor
 @Getter
-public class CategoryItemDetailResponse {
+public class CategoryInfoResponse {
 
 	private Long id;
 	private String title;
 
-	public static CategoryItemDetailResponse from(Category category) {
-		return new CategoryItemDetailResponse(category.getId(), category.getTitle());
+	public static CategoryInfoResponse from(Category category) {
+		return new CategoryInfoResponse(category.getId(), category.getTitle());
 	}
 }

--- a/src/main/java/com/codesquad/secondhand/item/application/dto/ItemDetailResponse.java
+++ b/src/main/java/com/codesquad/secondhand/item/application/dto/ItemDetailResponse.java
@@ -3,7 +3,7 @@ package com.codesquad.secondhand.item.application.dto;
 import java.time.LocalDateTime;
 import java.util.List;
 
-import com.codesquad.secondhand.category.application.dto.CategoryItemDetailResponse;
+import com.codesquad.secondhand.category.application.dto.CategoryInfoResponse;
 import com.codesquad.secondhand.category.domain.Category;
 import com.codesquad.secondhand.image.application.dto.ImageResponse;
 import com.codesquad.secondhand.item.domain.Item;
@@ -26,7 +26,7 @@ public class ItemDetailResponse {
 	private boolean isLiked;
 	private LocalDateTime updatedAt;
 	private StatusItemDetailResponse status;
-	private CategoryItemDetailResponse category;
+	private CategoryInfoResponse category;
 	private UserItemDetailResponse seller;
 	private List<ImageResponse> images;
 
@@ -37,7 +37,7 @@ public class ItemDetailResponse {
 		return new ItemDetailResponse(item.getId(), item.getTitle(), item.getContent(), item.getPrice(),
 			item.getChatCount(), item.getWishlistCount(), item.getViews(), item.isMyWishlisted(accountUser),
 			item.getUpdatedAt(),
-			StatusItemDetailResponse.from(status), CategoryItemDetailResponse.from(category),
+			StatusItemDetailResponse.from(status), CategoryInfoResponse.from(category),
 			UserItemDetailResponse.from(user), ImageResponse.from(item.getImages()));
 	}
 
@@ -81,7 +81,7 @@ public class ItemDetailResponse {
 		return status.getStatus();
 	}
 
-	public CategoryItemDetailResponse getCategory() {
+	public CategoryInfoResponse getCategory() {
 		return category;
 	}
 

--- a/src/main/java/com/codesquad/secondhand/item/application/dto/ItemSliceResponse.java
+++ b/src/main/java/com/codesquad/secondhand/item/application/dto/ItemSliceResponse.java
@@ -13,8 +13,6 @@ public class ItemSliceResponse {
 	private List<ItemResponse> items;
 
 	public static ItemSliceResponse of(boolean hasNext, List<ItemResponse> itemResponses) {
-		return new ItemSliceResponse(
-			hasNext, itemResponses.isEmpty() ? null : itemResponses
-		);
+		return new ItemSliceResponse(hasNext, itemResponses);
 	}
 }

--- a/src/main/java/com/codesquad/secondhand/item/application/dto/MyTransactionResponse.java
+++ b/src/main/java/com/codesquad/secondhand/item/application/dto/MyTransactionResponse.java
@@ -4,6 +4,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import com.codesquad.secondhand.category.application.dto.CategoryInfoResponse;
 import com.codesquad.secondhand.item.domain.Item;
 
 import lombok.AllArgsConstructor;
@@ -12,23 +13,32 @@ import lombok.Getter;
 @AllArgsConstructor
 @Getter
 public class MyTransactionResponse {
+
 	private Long id;
 	private String title;
 	private String region;
+	private String status;
 	private LocalDateTime updatedAt;
 	private Integer price;
-	private String thumbnail;
+	private String thumbnailUrl;
 	private Long sellerId;
+	private int numChat;
+	private int numLikes;
+	private CategoryInfoResponse category;
 
 	public static MyTransactionResponse of(Item item) {
 		return new MyTransactionResponse(
 			item.getId(),
 			item.getTitle(),
 			item.getRegion().getTitle(),
+			item.getStatus().getType(),
 			item.getUpdatedAt(),
 			item.getPrice(),
 			item.getThumbnailUrl(),
-			item.getSellerId()
+			item.getSellerId(),
+			item.getChatCount(),
+			item.getWishlistCount(),
+			CategoryInfoResponse.from(item.getCategory())
 		);
 	}
 

--- a/src/main/java/com/codesquad/secondhand/item/application/dto/MyTransactionSliceResponse.java
+++ b/src/main/java/com/codesquad/secondhand/item/application/dto/MyTransactionSliceResponse.java
@@ -13,8 +13,6 @@ public class MyTransactionSliceResponse {
 	private List<MyTransactionResponse> items;
 
 	public static MyTransactionSliceResponse of(boolean hasMore, List<MyTransactionResponse> myTransactionResponse) {
-		return new MyTransactionSliceResponse(
-			hasMore, myTransactionResponse.isEmpty() ? null : myTransactionResponse
-		);
+		return new MyTransactionSliceResponse(hasMore, myTransactionResponse);
 	}
 }

--- a/src/main/java/com/codesquad/secondhand/user/application/dto/MyWishlistSliceResponse.java
+++ b/src/main/java/com/codesquad/secondhand/user/application/dto/MyWishlistSliceResponse.java
@@ -14,8 +14,6 @@ public class MyWishlistSliceResponse {
 	private List<MyWishlistResponse> items;
 
 	public static MyWishlistSliceResponse of(boolean hasMore, List<MyWishlistResponse> myWishlistResponses) {
-		return new MyWishlistSliceResponse(
-			hasMore, myWishlistResponses.isEmpty() ? null : myWishlistResponses
-		);
+		return new MyWishlistSliceResponse(hasMore, myWishlistResponses);
 	}
 }

--- a/src/test/java/com/codesquad/secondhand/util/fixture/CategoryFixture.java
+++ b/src/test/java/com/codesquad/secondhand/util/fixture/CategoryFixture.java
@@ -5,7 +5,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
-import com.codesquad.secondhand.category.application.dto.CategoryItemDetailResponse;
+import com.codesquad.secondhand.category.application.dto.CategoryInfoResponse;
 
 public enum CategoryFixture {
 
@@ -72,12 +72,12 @@ public enum CategoryFixture {
 			.collect(Collectors.toUnmodifiableList());
 	}
 
-	public static CategoryItemDetailResponse findCategoryItemDetailResponseById(Long id) {
-		return findById(id).toCategoryItemDetailResponse();
+	public static CategoryInfoResponse findCategoryItemDetailResponseById(Long id) {
+		return findById(id).toCategoryInfoResponse();
 	}
 
-	public CategoryItemDetailResponse toCategoryItemDetailResponse() {
-		return new CategoryItemDetailResponse(id, title);
+	public CategoryInfoResponse toCategoryInfoResponse() {
+		return new CategoryInfoResponse(id, title);
 	}
 
 	public Long getId() {

--- a/src/test/java/com/codesquad/secondhand/util/fixture/ItemFixture.java
+++ b/src/test/java/com/codesquad/secondhand/util/fixture/ItemFixture.java
@@ -62,13 +62,23 @@ public enum ItemFixture {
 			id, title, content, price, numChat,
 			numLikes, views, false, LocalDateTime.now(),
 			StatusFixture.findById(statusId).toStatusItemDetailResponse(),
-			CategoryFixture.findById(categoryId).toCategoryItemDetailResponse(),
+			CategoryFixture.findById(categoryId).toCategoryInfoResponse(),
 			UserFixture.findById(userId).toUserItemDetailResponse(), imageResponses);
 	}
 
 	public MyTransactionResponse toMyTransactionResponse(String thumbnailUrl) {
 		return new MyTransactionResponse(
-			id, title, RegionFixture.findById(regionId).getTitle(), null, price, thumbnailUrl, userId
+			id,
+			title,
+			RegionFixture.findById(regionId).getTitle(),
+			StatusFixture.findById(statusId).getType(),
+			LocalDateTime.now(),
+			price,
+			thumbnailUrl,
+			userId,
+			0,
+			0,
+			CategoryFixture.findById(categoryId).toCategoryInfoResponse()
 		);
 	}
 

--- a/src/test/java/com/codesquad/secondhand/util/fixture/UserFixture.java
+++ b/src/test/java/com/codesquad/secondhand/util/fixture/UserFixture.java
@@ -6,9 +6,7 @@ import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.Objects;
 
-import com.codesquad.secondhand.category.application.dto.CategoryItemDetailResponse;
 import com.codesquad.secondhand.user.application.dto.UserItemDetailResponse;
-import com.codesquad.secondhand.user.domain.User;
 
 public enum UserFixture {
 


### PR DESCRIPTION
## 주요 변경 내용
- 의존성 버전관리 적용
- 판매 내역 응답에서 카테고리 아이디 추가
- 판매 내역, 상품 내역, 관심 상품 내역 응답에서 비어 있는 경우 Empty List 반환한게 변경

